### PR TITLE
metabase_user: fix ordering diff between the API and state (#37

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.6.1] - 2023-03-07
+
+### Fixed
+
+- `resource/metabase_user`: Fix an issue where an ordering mismatch between the API and state for the groups shows a perpetual diff
+
 ## [0.6.0] - 2023-02-17
 
 ### Added

--- a/internal/transforms/int64.go
+++ b/internal/transforms/int64.go
@@ -1,6 +1,7 @@
 package transforms
 
 import (
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"strconv"
 )
@@ -16,6 +17,20 @@ func FromTerraformInt64List(l types.List) *[]int64 {
 		}
 
 		return &newList
+	}
+}
+
+func ToTerraformInt64List(intList *[]int64) types.List {
+	if intList == nil {
+		return types.ListNull(types.Int64Type)
+	} else {
+		attrList := make([]attr.Value, len(*intList))
+		for i, val := range *intList {
+			attrList[i] = types.Int64Value(val)
+		}
+
+		newList, _ := types.ListValue(types.Int64Type, attrList)
+		return newList
 	}
 }
 

--- a/internal/transforms/int64_test.go
+++ b/internal/transforms/int64_test.go
@@ -1,6 +1,7 @@
 package transforms
 
 import (
+	"context"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/stretchr/testify/assert"
@@ -29,6 +30,29 @@ func TestFromTerraformInt64List(t *testing.T) {
 		intList := FromTerraformInt64List(tfIntList)
 
 		assert.Equal(t, []int64{1, 5, 9}, *intList)
+	})
+}
+
+func TestToTerraformInt64List(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil", func(t *testing.T) {
+		tfIntList := ToTerraformInt64List(nil)
+
+		assert.True(t, tfIntList.IsNull())
+		assert.Equal(t, types.Int64Type, tfIntList.ElementType(context.Background()))
+	})
+
+	t.Run("non-nil", func(t *testing.T) {
+		intList := []int64{1, 4, 9}
+		tfIntList := ToTerraformInt64List(&intList)
+
+		assert.False(t, tfIntList.IsNull())
+		assert.Equal(t, 3, len(tfIntList.Elements()))
+
+		var mappedIntList []int64
+		tfIntList.ElementsAs(context.Background(), &mappedIntList, false)
+		assert.Equal(t, intList, mappedIntList)
 	})
 }
 


### PR DESCRIPTION
This isn't a great solution, but the `metabase_user` resource will now use the existing state when reading from the API to set the order of the group IDs.

Fixes #36 